### PR TITLE
Fixed the brightwhite regex in puppet.nanorc.

### DIFF
--- a/puppet.nanorc
+++ b/puppet.nanorc
@@ -4,7 +4,7 @@ syntax "puppet" "\.pp$"
 
 #This goes first, so the normal builtins will override in some classes
 ## Paramerers
-color brightwhite "^[[:space::]]([a-z][a-z0-9_]+)"
+color brightwhite "^[[:space:]]([a-z][a-z0-9_]+)"
 
 ## List of built in types, also catches defines
 color yellow "\<(augeas|computer|cron|exec|file|filebucket|group|host|interface|k5login|macauthorization|mailalias|maillist|mcx|mount|nagios_command|nagios_contact|nagios_contactgroup|nagios_host|nagios_hostdependency|nagios_hostescalation|nagios_hostextinfo|nagios_hostgroup|nagios_service|nagios_servicedependency|nagios_serviceescalation|nagios_serviceextinfo|nagios_servicegroup|nagios_timeperiod|notify|package|resources|router|schedule|scheduled_task|selboolean|selmodule|service|ssh_authorized_key|sshkey|stage|tidy|user|vlan|yumrepo|zfs|zone|zpool|)\>"


### PR DESCRIPTION
The brightwhite regex threw an error.  There was an extra colon.
